### PR TITLE
Add HTTP/GET method support for non-VK servers

### DIFF
--- a/vkrelay/apirelay.php
+++ b/vkrelay/apirelay.php
@@ -11,7 +11,7 @@
 	$curl = curl_init($request);
 	curl_exec($curl);
 
-	$statusCode = curl_getinfo($ch, CURLINFO_HTTP_CODE);
+	$statusCode = curl_getinfo($curl, CURLINFO_HTTP_CODE);
 
 	if($statusCode === 301 && str_starts_with($request, "http://")) {
 		$request = str_replace("http://", "https://", $request);

--- a/vkrelay/apirelay.php
+++ b/vkrelay/apirelay.php
@@ -2,15 +2,22 @@
 	ob_start();
 	error_reporting(E_ALL);
 
-
 	header("Content-Type: text/json");
-	if(isset($_GET["goto"]))
+	if(strlen($_GET["goto"]) > 0)
 		$request = $_GET["goto"];
 	else
 		$request = file_get_contents("php://input");
 	
 	$curl = curl_init($request);
 	curl_exec($curl);
+
+	$statusCode = curl_getinfo($ch, CURLINFO_HTTP_CODE);
+
+	if($statusCode === 301 && str_starts_with($request, "http://")) {
+		$request = str_replace("http://", "https://", $request);
+		$curl = curl_init($request);
+		curl_exec($curl);
+	}
 	
 	header("Content-length: " . ob_get_length());
 	ob_flush();

--- a/vkrelay/apirelay.php
+++ b/vkrelay/apirelay.php
@@ -4,7 +4,10 @@
 
 
 	header("Content-Type: text/json");
-	$request = file_get_contents("php://input");
+	if(isset($_GET["goto"]))
+		$request = $_GET["goto"];
+	else
+		$request = file_get_contents("php://input");
 	
 	$curl = curl_init($request);
 	curl_exec($curl);


### PR DESCRIPTION
Это нужно для поддержки стриминга мультимедиа через обычный GET-запрос. Увы, MediaPlayer из Android API никак не умеет в POST-запросы (если только городить костыли по типу локального прокси на девайсе, может и заработать). Проще будет именно через GET-запросы.